### PR TITLE
Fix ManiaParser parsing error

### DIFF
--- a/src/main/java/lt/ekgame/beatmap_analyzer/parser/hitobjects/ManiaParser.java
+++ b/src/main/java/lt/ekgame/beatmap_analyzer/parser/hitobjects/ManiaParser.java
@@ -19,7 +19,7 @@ public class ManiaParser extends HitObjectParser<ManiaObject> {
 		int type = Integer.parseInt(args[3].trim());
 		int hitSound = Integer.parseInt(args[4].trim());
 				
-		if ((type & 1) > 0) {
+		if ((type & 7) > 0) {
 			return new ManiaSingle(position, time, hitSound);
 		}
 		else {


### PR DESCRIPTION
According to latest https://osu.ppy.sh/help/wiki/osu!_File_Formats/Osu_(file_format)
osu!mania hold note should be determined at 7th bit not 1st bit from the right